### PR TITLE
Add unit of work pattern for in-memory and SQLite repositories

### DIFF
--- a/application/book/service.py
+++ b/application/book/service.py
@@ -32,7 +32,13 @@ class BookService:
             isbn=isbn,
             publication_date=publication_date,
         )
-        self.book_repository.save(book)
+        self.book_repository.begin()
+        try:
+            self.book_repository.save(book)
+            self.book_repository.commit()
+        except Exception:
+            self.book_repository.rollback()
+            raise
 
         event = application.book.event.BookAdded(title=book.title, author=book.author)
         self.event_bus.publish(event)

--- a/domain/book/repository.py
+++ b/domain/book/repository.py
@@ -4,7 +4,21 @@ from typing import List, Optional
 import domain.book.entity
 
 
-class BookRepository(ABC):
+class UnitOfWork(ABC):
+    @abstractmethod
+    def begin(self):
+        pass
+
+    @abstractmethod
+    def commit(self):
+        pass
+
+    @abstractmethod
+    def rollback(self):
+        pass
+
+
+class BookRepository(UnitOfWork, ABC):
     @abstractmethod
     def save(self, book: domain.book.entity.Book):
         pass

--- a/infrastructure/book/repository.py
+++ b/infrastructure/book/repository.py
@@ -7,6 +7,22 @@ import domain.book.entity
 class InMemoryBookRepository(domain.book.repository.BookRepository):
     def __init__(self):
         self.books: Dict[uuid.UUID, domain.book.entity.Book] = {}
+        self._transaction_active = False
+        self._backup_books = {}
+
+    def begin(self):
+        self._transaction_active = True
+        self._backup_books = self.books.copy()
+
+    def commit(self):
+        self._transaction_active = False
+        self._backup_books = {}
+
+    def rollback(self):
+        if self._transaction_active:
+            self.books = self._backup_books
+            self._transaction_active = False
+            self._backup_books = {}
 
     def save(self, book: domain.book.entity.Book):
         if book.id is None:
@@ -36,6 +52,7 @@ class SQLiteBookRepository(BookRepository):
     def __init__(self, db_path: str):
         self.db_path = db_path
         self._initialize_database()
+        self._transaction_active = False
 
     def _initialize_database(self):
         """Create the books table if it doesn't exist."""
@@ -54,39 +71,62 @@ class SQLiteBookRepository(BookRepository):
             )
             conn.commit()
 
+    def begin(self):
+        self._transaction_active = True
+        self._conn = sqlite3.connect(self.db_path)
+        self._cursor = self._conn.cursor()
+
+    def commit(self):
+        if self._transaction_active:
+            self._conn.commit()
+            self._conn.close()
+            self._transaction_active = False
+
+    def rollback(self):
+        if self._transaction_active:
+            self._conn.rollback()
+            self._conn.close()
+            self._transaction_active = False
+
     def save(self, book: Book):
         """Save a book to the database."""
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            if book.id is None:
-                book.id = str(uuid.uuid4())  # Generate a new UUID if not set
-                cursor.execute(
-                    """
-                    INSERT INTO books (id, title, author, isbn, publication_date)
-                    VALUES (?, ?, ?, ?, ?)
-                """,
-                    (
-                        book.id,
-                        book.title,
-                        book.author,
-                        book.isbn.value,
-                        book.publication_date,
-                    ),
-                )
-            else:
-                cursor.execute(
-                    """
-                    REPLACE INTO books (id, title, author, isbn, publication_date)
-                    VALUES (?, ?, ?, ?, ?)
-                """,
-                    (
-                        book.id,
-                        book.title,
-                        book.author,
-                        book.isbn.value,
-                        book.publication_date,
-                    ),
-                )
+        if self._transaction_active:
+            cursor = self._cursor
+        else:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+
+        if book.id is None:
+            book.id = str(uuid.uuid4())  # Generate a new UUID if not set
+            cursor.execute(
+                """
+                INSERT INTO books (id, title, author, isbn, publication_date)
+                VALUES (?, ?, ?, ?, ?)
+            """,
+                (
+                    book.id,
+                    book.title,
+                    book.author,
+                    book.isbn.value,
+                    book.publication_date,
+                ),
+            )
+        else:
+            cursor.execute(
+                """
+                REPLACE INTO books (id, title, author, isbn, publication_date)
+                VALUES (?, ?, ?, ?, ?)
+            """,
+                (
+                    book.id,
+                    book.title,
+                    book.author,
+                    book.isbn.value,
+                    book.publication_date,
+                ),
+            )
+
+        if not self._transaction_active:
             conn.commit()
 
     def find_by_id(self, book_id: str) -> Optional[Book]:


### PR DESCRIPTION
Implement a unit of work pattern for both in-memory and SQLite repository implementations.

* **domain/book/repository.py**
  - Add `UnitOfWork` interface with `begin`, `commit`, and `rollback` methods.
  - Update `BookRepository` interface to inherit from `UnitOfWork`.

* **infrastructure/book/repository.py**
  - Implement `UnitOfWork` for `InMemoryBookRepository` with `begin`, `commit`, and `rollback` methods.
  - Implement `UnitOfWork` for `SQLiteBookRepository` with `begin`, `commit`, and `rollback` methods.
  - Update `save` method in `SQLiteBookRepository` to handle transactions.

* **application/book/service.py**
  - Update `BookService` to use `UnitOfWork` for repository operations.
  - Modify `add_book` method to use `UnitOfWork` for transaction management.

